### PR TITLE
Fixes `header': wrong number of arguments (3 for 2)

### DIFF
--- a/lib/md2man/html.rb
+++ b/lib/md2man/html.rb
@@ -22,7 +22,7 @@ module Md2Man::HTML
     "<dl><dd>#{text}</dd></dl>"
   end
 
-  def header text, level
+  def header text, level, _=nil
     id = text.gsub(/<.+?>/, '-').        # strip all HTML tags
       gsub(/\W+/, '-').gsub(/^-|-$/, '') # fold non-word chars
     %{<h#{level} id="#{id}">#{text}</h#{level}>}

--- a/lib/md2man/roff.rb
+++ b/lib/md2man/roff.rb
@@ -54,7 +54,7 @@ module Md2Man::Roff
     warn "md2man/roff: block_html not implemented: #{html.inspect}"
   end
 
-  def header text, level
+  def header text, level, _=nil
     macro =
       case level
       when 1


### PR DESCRIPTION
I don't know if it's because of my version of RedCarpet (3.1.1) but I'm getting these errors. The 3rd argument seems to be the lower-cased version of the first argument (maybe an ID ?). In any case, that change should be backward-compatible
