### PR TITLE
Fixes code block escaping for lines that start with a dot.

### DIFF
--- a/lib/md2man/roff.rb
+++ b/lib/md2man/roff.rb
@@ -42,7 +42,7 @@ module Md2Man::Roff
   end
 
   def block_code code, language
-    code = escape_backslashes(code)
+    code = escape_macro escape_backslashes(code)
     block_quote "\n.nf\n#{code.chomp}\n.fi\n"
   end
 
@@ -219,6 +219,10 @@ module Md2Man::Roff
   end
 
 private
+
+  def escape_macro text
+    text.gsub(/^\./, '\\\\&.')
+  end
 
   def escape_backslashes text
     text.gsub(/\\/, '\&\&')


### PR DESCRIPTION
Tried on and fixes the provided sample in #17. I don't really know if other kind of blocks could benefit from that escaping.
