### PR TITLE
Fix ordered list with nest

### DIFF
--- a/lib/md2man/roff.rb
+++ b/lib/md2man/roff.rb
@@ -80,6 +80,7 @@ module Md2Man::Roff
 
     if list_type == :ordered
       result << ".nr step#{@ordered_list_id} 0 1"
+      contents.gsub!(/^\.IP \\n\+\[step_tbd\]$/, ".IP \\n+[step#{@ordered_list_id}]")
       @ordered_list_id += 1
     end
 
@@ -91,7 +92,7 @@ module Md2Man::Roff
     designator =
       case list_type
       when :ordered
-        "\\n+[step#{@ordered_list_id}]"
+        "\\n+[step_tbd]"
       when :unordered
         "\\(bu 2"
       end

--- a/test/md2man/roff_test.rb
+++ b/test/md2man/roff_test.rb
@@ -739,17 +739,20 @@ describe 'roff engine' do
     @markdown.render(heredoc(<<-INPUT)).must_equal(heredoc(<<-OUTPUT))
       |Here is an ordered list:
       |
-      |1.  foo
+      |1.  foo1
+      |2.  foo2
       |    1.  bar
       |        1.  baz
-      |2.  qux
+      |3.  qux
     INPUT
       |.PP
       |Here is an ordered list:
       |.nr step2 0 1
       |.RS
       |.IP \\n+[step2]
-      |foo
+      |foo1
+      |.IP \\n+[step2]
+      |foo2
       |.nr step1 0 1
       |.RS
       |.IP \\n+[step1]


### PR DESCRIPTION
With below markdown:

```markdown
1. foo1
2. foo2
    1. bar
        1. buz
3. qux
```

I expect the following result:

```
              1      foo1

              2      foo2

                     1      bar

                            1      buz

              3      qux
```

However, in actual:

```
              0      foo1

              1      foo2

                     1      bar

                            1      buz

              2      qux
```

This PR fix this behavior.